### PR TITLE
Update link for rename NLog.Framework.logging => NLog.Extensions.Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Community projects adapt _Microsoft.Extensions.Logging_ for use with different b
  * [Serilog](https://github.com/serilog/serilog-framework-logging) - provider for the Serilog library
  * [elmah.io](https://github.com/elmahio/Elmah.Io.Framework.Logging) - provider for the elmah.io service
  * [Loggr](https://github.com/imobile3/Loggr.Extensions.Logging) - provider for the Loggr service
- * [NLog](https://github.com/NLog/NLog.Framework.logging) - provider for the NLog library
+ * [NLog](https://github.com/NLog/NLog.Extensions.Logging) - provider for the NLog library
  


### PR DESCRIPTION
for consistency
